### PR TITLE
Fix types of loadbalancer-related parameters

### DIFF
--- a/lib/saklient/cloud/resources/lb_server.rb
+++ b/lib/saklient/cloud/resources/lb_server.rb
@@ -304,7 +304,7 @@ module Saklient
           ])
           port = Saklient::Util::get_by_path_any([obj], ['Port', 'port'])
           @_port = nil
-          @_port = (port).to_s().to_i(10) if !(port).nil?
+          @_port = (port).to_s() if !(port).nil?
           @_port = nil if @_port == 0
           responseExpected = Saklient::Util::get_by_path_any([health, obj], [
             'Status',
@@ -313,7 +313,7 @@ module Saklient
             'response_expected'
           ])
           @_response_expected = nil
-          @_response_expected = (responseExpected).to_s().to_i(10) if !(responseExpected).nil?
+          @_response_expected = (responseExpected).to_s() if !(responseExpected).nil?
           @_response_expected = nil if @_response_expected == 0
           @_active_connections = 0
           @_status = nil

--- a/lib/saklient/cloud/resources/lb_virtual_ip.rb
+++ b/lib/saklient/cloud/resources/lb_virtual_ip.rb
@@ -192,7 +192,7 @@ module Saklient
           @_virtual_ip_address = vip
           port = Saklient::Util::get_by_path_any([obj], ['Port', 'port'])
           @_port = nil
-          @_port = (port).to_s().to_i(10) if !(port).nil?
+          @_port = (port).to_s() if !(port).nil?
           @_port = nil if @_port == 0
           delayLoop = Saklient::Util::get_by_path_any([obj], [
             'DelayLoop',
@@ -201,7 +201,7 @@ module Saklient
             'delay'
           ])
           @_delay_loop = nil
-          @_delay_loop = (delayLoop).to_s().to_i(10) if !(delayLoop).nil?
+          @_delay_loop = (delayLoop).to_s() if !(delayLoop).nil?
           @_delay_loop = nil if @_delay_loop == 0
           sorryServer = Saklient::Util::get_by_path_any([obj], [
             'SorryServer',


### PR DESCRIPTION
2017年頃に使用していたロードバランサを起動するスクリプトを、最近実行してみると動かなくなっていることに気づきました。

```
require 'saklient/cloud/api'

TOKEN = "token"
SECRET = "secret"
ZONE = "tk1v"

api = Saklient::Cloud::API::authorize(TOKEN, SECRET, ZONE)
sw = api.swytch.with_name_like("net-test").limit(1).find.first
lb = api.appliance.create_load_balancer(sw, 123, ["x.x.x.4"], false)
lb.name = "lb-low"

servers = [
  { ip: "x.x.x.7", port: 80, protocol: "http",
    path_to_check: '/index.html', response_expected: 200,
    Enabled: "True" },
  { ip: "x.x.x.8", port: 80, protocol: "http",
    path_to_check: '/index.html', response_expected: 200,
    Enabled: "True" }
]

lb.add_virtual_ip({ vip: "x.x.x.6", port: 80, delay: 15, sorry_server: "",
                    servers: servers })

lb.save
lb.sleep_while_creating
lb.sleep_until_up
lb.apply
```

例えば、上記の様なコードを実行すると`Integer value found, but a string is required`のエラーメッセージが返って来ます。

```
$ ruby create_lb.rb
Traceback (most recent call last):
	3: from create_lb.rb:24:in `<main>'
	2: from /Users/username/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/saklient-0.0.10/lib/saklient/cloud/resources/appliance.rb:136:in `save'
	1: from /Users/username/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/saklient-0.0.10/lib/saklient/cloud/resources/resource.rb:239:in `_save'
/Users/username/.rbenv/versions/2.6.5/lib/ruby/gems/2.6.0/gems/saklient-0.0.10/lib/saklient/cloud/client.rb:110:in `request': 不適切な要求です。パラメータの指定誤り、入力規則違反です。入力内容をご確認ください。 (Saklient::Errors::HttpBadRequestException)
Integer value found, but a string is required
Integer value found, but a string is required
Integer value found, but a string is required
Integer value found, but a string is required
Integer value found, but a string is required
Integer value found, but a string is required
```

調べてみたところ、現行のAPIサーバでは、 port, response_expected, delay などのパラメータのタイプとしてIntegerではなく、Stringを受け付ける事が原因でした。

APIの仕様の変更については探してみましたが見当たりませんでした。

https://developer.sakura.ad.jp/cloud/api/1.1/appliance/
ドキュメントの例では、これらのパラメータにIntegerが使用されていますが、実際にはIntegerは受け付けません。

curl, Python SDKでも試してみましたが、同様のエラーが発生しましたので、APIの方の仕様が変わったのではないかと推察しています。

これらのパラメータは内部的に `.to_i(10)` メソッドで自動変換されていますので、
もし現行のAPIサーバの仕様が正しいとするとSDKの方を変更する必要があるかと思います。

この pull request では、 `.to_s().to_i(10)` を `.to_s()` に変更することで、該当パラメータをStringとしてリクエストを実行するようにしています。